### PR TITLE
missing libssl-dev in ubuntu/debian reqs

### DIFF
--- a/installation.rst
+++ b/installation.rst
@@ -237,6 +237,7 @@ On Ubuntu or Debian install the following dependencies:
         uuid-dev \
         libgpgme-dev \
         squashfs-tools \
+        libssl-dev \
         libseccomp-dev \
         wget \
         pkg-config \


### PR DESCRIPTION
Just an aside, probably beyond the scope of what you want to include in this doc, but golang is also a working option via apt for Ubuntu 20+; the default package is currently at 1.13.