### PR TITLE
Github hosted docs

### DIFF
--- a/.github/workflows/generate-web.yaml
+++ b/.github/workflows/generate-web.yaml
@@ -1,0 +1,70 @@
+name: Singularity Admin Docs Hosting
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  Build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract branch name
+        id: extract
+        shell: bash
+        run: echo ::set-output name=branch::${GITHUB_REF#refs/*/}
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Checkout Docs
+        uses: actions/checkout@v2
+        with:
+            fetch-depth: 0
+            path: build
+
+      - name: Install Deps
+        run: |
+            sudo apt-get update -y && \
+            sudo apt-get install -f -y texlive-latex-extra latexmk
+
+      - name: Install Sphinx
+        run: pip install sphinx sphinx-rtd-theme restructuredtext_lint pygments
+
+      - name: Build HTML
+        working-directory: build
+        run: make html
+
+      - name: Checkout Docs
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: gh-pages
+          path: push
+
+      - name: Prep repo
+        working-directory: push
+        run: rm -rf docs/${{ steps.extract.outputs.branch }} && mkdir docs/${{ steps.extract.outputs.branch }}
+
+      - name: Copy Generated Docs
+        run: cp -r ./build/_build/html/* ./push/docs/${{ steps.extract.outputs.branch }}
+
+      - name: Add Jekyll Ignore
+        working-directory: push
+        run: touch docs/${{ steps.extract.outputs.branch }}/.nojekyll
+
+      - name: Setup Git Info
+        run: |
+            git config --global user.email "ci@hpcng.org"
+            git config --global user.name "singularity-admin-docs-ci"
+
+      - name: Commit Docs
+        working-directory: push
+        run: git add . && git commit -m "auto-generated commit"  --allow-empty
+
+      - name: Push Docs
+        working-directory: push
+        run: git push origin gh-pages

--- a/admin_quickstart.rst
+++ b/admin_quickstart.rst
@@ -273,5 +273,5 @@ Sylabs Container Library:
 
 
 See the `user guide
-<https://www.sylabs.io/guides/\{userversion\}/user-guide/>`__ for more
+<\{userdocbaseurl\}/\{userversion\}/>`__ for more
 information about how to use Singularity.

--- a/configfiles.rst
+++ b/configfiles.rst
@@ -52,7 +52,7 @@ when running a container by default. Options include:
 
   The root user can manage the capabilities granted to individual containers when they
   are launched through the ``--add-caps`` and ``drop-caps`` flags.
-  Please see `Linux Capabilities <https://sylabs.io/guides/\{userversion\}/user-guide/security_options.html#linux-capabilities>`_
+  Please see `Linux Capabilities <\{userdocbaseurl\}/\{userversion\}/security_options.html#linux-capabilities>`_
   in the user guide for more information.
 
 Loop Devices
@@ -298,11 +298,11 @@ customized by system admins and referenced with the options below:
 
 ``CNI CONFIGURATION PATH``:
 This option allows admins to specify a custom path for the CNI configuration
-that Singularity will use for `Network Virtualization <https://sylabs.io/guides/\{userversion\}/user-guide/networking.html>`_.
+that Singularity will use for `Network Virtualization <\{userdocbaseurl\}/\{userversion\}/networking.html>`_.
 
 ``CNI PLUGIN PATH``:
 This option allows admins to specify a custom path for Singularity to access
-CNI plugin executables. Check out the `Network Virtualization <https://sylabs.io/guides/\{userversion\}/user-guide/networking.html>`_
+CNI plugin executables. Check out the `Network Virtualization <\{userdocbaseurl\}/\{userversion\}/networking.html>`_
 section of the user guide for more information.
 
 ``MKSQUASHFS PATH``:
@@ -630,7 +630,7 @@ host drivers/libraries is dependent on the versions of the GPU compute
 frameworks that were used to build the applications. Compatibility and
 usage information is discussed in the `GPU Support` section of the
 `user guide
-<https://www.sylabs.io/guides/\{userversion\}/user-guide/>`__
+<\{userdocbaseurl\}/\{userversion\}/>`__
 
 
 NVIDIA GPUs / CUDA
@@ -804,8 +804,8 @@ Use the ``--security`` option to invoke the container like:
   $ sudo singularity shell --security seccomp:/home/david/my.json my_container.sif
 
 For more insight into security options, network options, cgroups, capabilities,
-etc, please check the `Userdocs <https://www.sylabs.io/guides/\{userversion\}/user-guide/>`_
-and it's `Appendix <https://www.sylabs.io/guides/\{userversion\}/user-guide/appendix.html>`_.
+etc, please check the `Userdocs <\{userdocbaseurl\}/\{userversion\}/>`_
+and it's `Appendix <\{userdocbaseurl\}/\{userversion\}/appendix.html>`_.
 
 ------------
 remote.yaml
@@ -884,7 +884,7 @@ the only usable remote for the system by using the ``--exclusive`` flag:
     * Active cloud services keyserver
 
 For more details on the ``remote`` command group and managing remote endpoints,
-please check the `Remote Userdocs <https://www.sylabs.io/guides/\{userversion\}/user-guide/endpoint.html>`_.
+please check the `Remote Userdocs <\{userdocbaseurl\}/\{userversion\}/endpoint.html>`_.
 
 
 .. note::
@@ -904,4 +904,4 @@ administrator to create a global list of key servers used to verify container
 signatures by default.
 
 For more details on the ``remote`` command group and managing keyservers,
-please check the `Remote Userdocs <https://www.sylabs.io/guides/\{userversion\}/user-guide/endpoint.html>`_.
+please check the `Remote Userdocs <\{userdocbaseurl\}/\{userversion\}/endpoint.html>`_.

--- a/index.rst
+++ b/index.rst
@@ -9,7 +9,7 @@ detail, and other topics important to system adminstrators working
 with Singularity.
 
 See the `user guide
-<https://www.sylabs.io/guides/\{userversion\}/user-guide/>`__ for more
+<\{userdocbaseurl\}/\{userversion\}/>`__ for more
 information about how to use Singularity.
 
 .. toctree::

--- a/installation.rst
+++ b/installation.rst
@@ -589,7 +589,7 @@ library:
 
 
 See the `user guide
-<https://www.sylabs.io/guides/\{userversion\}/user-guide/>`__ for more
+<\{userdocbaseurl\}/\{userversion\}/>`__ for more
 information about how to use Singularity.
 
 singularity buildcfg

--- a/replacements.py
+++ b/replacements.py
@@ -11,7 +11,9 @@ def variableReplace(app, docname, source):
 variable_replacements = {
     "{InstallationVersion}" : "3.7.0",
     "\{adminversion\}" : "3.7",
-    "\{userversion\}" : "3.7"
+    "\{userversion\}" : "3.7",
+    "\{admindocbaseurl\}" : "https://hpcng.github.io/singularity-admindocs",
+    "\{userdocbaseurl\}" : "https://hpcng.github.io/singularity-userdocs"
 }
 
 def setup(app):

--- a/replacements.py
+++ b/replacements.py
@@ -10,8 +10,8 @@ def variableReplace(app, docname, source):
 #Add the needed variables to be replaced either on code or on text on the next dictionary structure.
 variable_replacements = {
     "{InstallationVersion}" : "3.7.0",
-    "\{adminversion\}" : "3.7",
-    "\{userversion\}" : "3.7",
+    "\{adminversion\}" : "master",
+    "\{userversion\}" : "master",
     "\{admindocbaseurl\}" : "https://hpcng.github.io/singularity-admindocs",
     "\{userdocbaseurl\}" : "https://hpcng.github.io/singularity-userdocs"
 }

--- a/security.rst
+++ b/security.rst
@@ -100,9 +100,9 @@ Admin Configurable Files
 #########################
 
 Singularity Administrators have the ability to access various configuration files, that will let them set security 
-restrictions, grant or revoke a user’s capabilities, manage resources and authorize containers etc. One such file interesting in this context is `ecl.toml <https://sylabs.io/guides/\{adminversion\}/admin-guide/configfiles.html#ecl-toml>`_ 
+restrictions, grant or revoke a user’s capabilities, manage resources and authorize containers etc. One such file interesting in this context is `ecl.toml <\{admindocbaseurl\}/configfiles.html#ecl-toml>`_
 which allows blacklisting and whitelisting of containers. You can find all the configuration files and their parameters
-documented `here <https://sylabs.io/guides/\{adminversion\}/admin-guide/configfiles.html>`__. 
+documented `here <\{admindocbaseurl\}/\{adminversion\}/configfiles.html>`__.
 
 cgroups support
 ****************
@@ -112,14 +112,14 @@ without the help of a separate program like a batch scheduling system. This feat
 container seizes control of all available system resources in order to stop other containers from operating properly. 
 To utilize this feature, a user first creates a configuration file. An example configuration file is installed by default with 
 Singularity to provide a guide. At runtime, the ``--apply-cgroups`` option is used to specify the location of the configuration 
-file and cgroups are configured accordingly. More about cgroups support `here <https://sylabs.io/guides/\{adminversion\}/admin-guide/configfiles.html#cgroups-toml>`__.
+file and cgroups are configured accordingly. More about cgroups support `here <\{admindocbaseurl\}/\{adminversion\}/configfiles.html#cgroups-toml>`__.
 
 ``--security`` options
 ***********************
 
 Singularity supports a number of methods for specifying the security scope and context when running Singularity containers. 
 Additionally, it supports new flags that can be passed to the action commands; ``shell``, ``exec``, and ``run`` allowing fine 
-grained control of security. Details about them are documented `here <https://sylabs.io/guides/\{userversion\}/user-guide/security_options.html>`__.
+grained control of security. Details about them are documented `here <\{userdocbaseurl\}/\{userversion\}/security_options.html>`__.
 
 Security in SCS
 ################


### PR DESCRIPTION
## Description of the Pull Request (PR):

This pr creates a github workflow that will generate documentation for this repository using github pages and does several things:
1. Introduces a tempate for the base url, including hostname, that the documentation is hosted at to allow self referencing and user doc referencing urls to function properly.
2. Removes `/user-guide` and `/admin-guide` components of documentation paths. I am happy to undo this if it will cause significant issues to existing documentation hosts.
3. Adds a CI workflow on pushes to `master` that trigger documentation within the `gh-pages` branch of this repository to have updated documentation under `docs/master`.


## Extra preparation needed to make this live for this repository:
1. Enable github pages for the repo and specify the branch as `gh-pages` and the directory as `docs`.
2. Add `.nojekyll` files to the `gh-pages` branch root and `docs` directory`
3. (Optional) Add `index.html` redirect to "lastest" doc directory

## Example:
An example is live at my personal fork: https://ikaneshiro.github.io/singularity-admindocs
Relevant branches are `master` and `gh-pages`