### PR TITLE
Simplify hyperlinks

### DIFF
--- a/admin_quickstart.rst
+++ b/admin_quickstart.rst
@@ -273,5 +273,5 @@ Sylabs Container Library:
 
 
 See the `user guide
-<https://singularity.hpcng.org/user-docs/\{userversion\}>`__ for more
+<\{userdocs\}>`__ for more
 information about how to use Singularity.

--- a/configfiles.rst
+++ b/configfiles.rst
@@ -52,7 +52,7 @@ when running a container by default. Options include:
 
   The root user can manage the capabilities granted to individual containers when they
   are launched through the ``--add-caps`` and ``drop-caps`` flags.
-  Please see `Linux Capabilities <https://singularity.hpcng.org/user-docs/\{userversion\}/security_options.html#linux-capabilities>`_
+  Please see `Linux Capabilities <\{userdocs\}/security_options.html#linux-capabilities>`_
   in the user guide for more information.
 
 Loop Devices
@@ -257,7 +257,7 @@ Networking Options
 The ``--network`` option can be used to specify a CNI networking
 configuration that will be used when running a container with `network
 virtualization
-<https://singularity.hpcng.org/user-docs/\{userversion\}/networking.html>`_. Unrestricted
+<\{userdocs\}/networking.html>`_. Unrestricted
 use of CNI network configurations requires root privilege, as certain
 configurations may disrupt the host networking environment.
 
@@ -332,11 +332,11 @@ customized by system admins and referenced with the options below:
 
 ``CNI CONFIGURATION PATH``:
 This option allows admins to specify a custom path for the CNI configuration
-that Singularity will use for `Network Virtualization <https://singularity.hpcng.org/user-docs/\{userversion\}/networking.html>`_.
+that Singularity will use for `Network Virtualization <\{userdocs\}/networking.html>`_.
 
 ``CNI PLUGIN PATH``:
 This option allows admins to specify a custom path for Singularity to access
-CNI plugin executables. Check out the `Network Virtualization <https://singularity.hpcng.org/user-docs/\{userversion\}/networking.html>`_
+CNI plugin executables. Check out the `Network Virtualization <\{userdocs\}/networking.html>`_
 section of the user guide for more information.
 
 ``MKSQUASHFS PATH``:
@@ -664,7 +664,7 @@ host drivers/libraries is dependent on the versions of the GPU compute
 frameworks that were used to build the applications. Compatibility and
 usage information is discussed in the `GPU Support` section of the
 `user guide
-<https://singularity.hpcng.org/user-docs/\{userversion\}>`__
+<\{userdocs\}>`__
 
 
 NVIDIA GPUs / CUDA
@@ -838,8 +838,8 @@ Use the ``--security`` option to invoke the container like:
   $ sudo singularity shell --security seccomp:/home/david/my.json my_container.sif
 
 For more insight into security options, network options, cgroups, capabilities,
-etc, please check the `Userdocs <https://singularity.hpcng.org/user-docs/\{userversion\}>`_
-and it's `Appendix <https://singularity.hpcng.org/user-docs/\{userversion\}/appendix.html>`_.
+etc, please check the `Userdocs <\{userdocs\}>`_
+and it's `Appendix <\{userdocs\}/appendix.html>`_.
 
 ------------
 remote.yaml
@@ -918,7 +918,7 @@ the only usable remote for the system by using the ``--exclusive`` flag:
     * Active cloud services keyserver
 
 For more details on the ``remote`` command group and managing remote endpoints,
-please check the `Remote Userdocs <https://singularity.hpcng.org/user-docs/\{userversion\}/endpoint.html>`_.
+please check the `Remote Userdocs <\{userdocs\}/endpoint.html>`_.
 
 
 .. note::
@@ -938,4 +938,4 @@ administrator to create a global list of key servers used to verify container
 signatures by default.
 
 For more details on the ``remote`` command group and managing keyservers,
-please check the `Remote Userdocs <https://singularity.hpcng.org/user-docs/\{userversion\}/endpoint.html>`_.
+please check the `Remote Userdocs <\{userdocs\}/endpoint.html>`_.

--- a/index.rst
+++ b/index.rst
@@ -9,7 +9,7 @@ detail, and other topics important to system adminstrators working
 with Singularity.
 
 See the `user guide
-<https://singularity.hpcng.org/user-docs/\{userversion\}>`__ for more
+<\{userdocs\}>`__ for more
 information about how to use Singularity.
 
 .. toctree::

--- a/installation.rst
+++ b/installation.rst
@@ -589,7 +589,7 @@ library:
 
 
 See the `user guide
-<https://singularity.hpcng.org/\{userversion\}>`__ for more
+<\{userdocs\}>`__ for more
 information about how to use Singularity.
 
 singularity buildcfg

--- a/replacements.py
+++ b/replacements.py
@@ -10,8 +10,7 @@ def variableReplace(app, docname, source):
 #Add the needed variables to be replaced either on code or on text on the next dictionary structure.
 variable_replacements = {
     "{InstallationVersion}" : "3.7.0",
-    "\{adminversion\}" : "3.7",
-    "\{userversion\}" : "3.7"
+    "\{userdocs\}" : "https://singularity.hpcng.org/user-docs/3.7"
 }
 
 def setup(app):

--- a/security.rst
+++ b/security.rst
@@ -119,7 +119,7 @@ file and cgroups are configured accordingly. More about cgroups support `here <c
 
 Singularity supports a number of methods for specifying the security scope and context when running Singularity containers. 
 Additionally, it supports new flags that can be passed to the action commands; ``shell``, ``exec``, and ``run`` allowing fine 
-grained control of security. Details about them are documented `here <https://singularity.hpcng.org/user-docs/\{userversion\}/security_options.html>`__.
+grained control of security. Details about them are documented `here <\{userdocs\}/security_options.html>`__.
 
 Security in SCS
 ################

--- a/security.rst
+++ b/security.rst
@@ -100,9 +100,9 @@ Admin Configurable Files
 #########################
 
 Singularity Administrators have the ability to access various configuration files, that will let them set security 
-restrictions, grant or revoke a user’s capabilities, manage resources and authorize containers etc. One such file interesting in this context is `ecl.toml <https://singularity.hpcng.org/admin-docs/master/configfiles.html#ecl-toml>`_ 
+restrictions, grant or revoke a user’s capabilities, manage resources and authorize containers etc. One such file interesting in this context is `ecl.toml <configfiles.html#ecl-toml>`_ 
 which allows blacklisting and whitelisting of containers. You can find all the configuration files and their parameters
-documented `here <https://singularity.hpcng.org/admin-docs/\{adminversion\}/configfiles.html>`__. 
+documented `here <configfiles.html>`__. 
 
 cgroups support
 ****************
@@ -112,14 +112,14 @@ without the help of a separate program like a batch scheduling system. This feat
 container seizes control of all available system resources in order to stop other containers from operating properly. 
 To utilize this feature, a user first creates a configuration file. An example configuration file is installed by default with 
 Singularity to provide a guide. At runtime, the ``--apply-cgroups`` option is used to specify the location of the configuration 
-file and cgroups are configured accordingly. More about cgroups support `here <https://singularity.hpcng.org/admin-docs/\{adminversion\}/configfiles.html#cgroups-toml>`__.
+file and cgroups are configured accordingly. More about cgroups support `here <configfiles.html#cgroups-toml>`__.
 
 ``--security`` options
 ***********************
 
 Singularity supports a number of methods for specifying the security scope and context when running Singularity containers. 
 Additionally, it supports new flags that can be passed to the action commands; ``shell``, ``exec``, and ``run`` allowing fine 
-grained control of security. Details about them are documented `here <https://singularity.hpcng.org/admin-docs/\{adminversion\}/security_options.html>`__.
+grained control of security. Details about them are documented `here <https://singularity.hpcng.org/user-docs/\{userversion\}/security_options.html>`__.
 
 Security in SCS
 ################


### PR DESCRIPTION
Replace references to admin-docs with just a relative URL, and replace references to user-docs with a macro for the whole url prefix instead of just the version number.